### PR TITLE
Add support for 'Edge Anaheim'

### DIFF
--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -4,7 +4,7 @@ class UserAgent
       OS_REGEXP = /Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/
 
       def self.extend?(agent)
-        agent.last && agent.last.product == "Edge"
+        agent.last && %w(Edge Edg).include?(agent.last.product)
       end
 
       def browser

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -41,3 +41,19 @@ describe "Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Win
     expect(@useragent.os).to eq("Windows 10")
   end
 end
+
+describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24")
+  end
+
+  it_should_behave_like "Edge browser"
+
+  it "should return '13.10586' as its version" do
+    expect(@useragent.version).to eq("74.1.96.24")
+  end
+
+  it "should return 'Windows 10' as its os" do
+    expect(@useragent.os).to eq("Windows 10")
+  end
+end


### PR DESCRIPTION
The new Edge 'Anaheim' builds have an update product name. This is for the line of Edge that's based off of Chromium. More info, including a sample UA, is found at https://blogs.windows.com/msedgedev/2019/04/08/microsoft-edge-preview-channel-details/#EbM5r2Iy2Xi0Dj5p.97

via @oreoshake / https://github.com/gshutler/useragent/pull/59