### PR TITLE
Add support for Edge on non-Windows OS

### DIFF
--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -15,12 +15,36 @@ class UserAgent
         last.version
       end
 
+      def application
+        self.reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
+      end
+
       def platform
-        "Windows"
+        return unless application
+
+        if application.comment[0] =~ /Windows/
+          'Windows'
+        elsif application.comment.any? { |c| c =~ /CrOS/ }
+          'ChromeOS'
+        elsif application.comment.any? { |c| c =~ /Android/ }
+          'Android'
+        else
+          application.comment[0]
+        end
       end
 
       def os
-        OperatingSystems.normalize_os(os_comment)
+        return unless application
+
+        if application.comment[0] =~ /Windows NT/
+          OperatingSystems.normalize_os(application.comment[0])
+        elsif application.comment[2].nil?
+          OperatingSystems.normalize_os(application.comment[1])
+        elsif application.comment[1] =~ /Android/
+          OperatingSystems.normalize_os(application.comment[1])
+        else
+          OperatingSystems.normalize_os(application.comment[2])
+        end
       end
 
       private

--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -4,7 +4,7 @@ class UserAgent
       OS_REGEXP = /Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/
 
       def self.extend?(agent)
-        agent.last && %w(Edge Edg).include?(agent.last.product)
+        agent.last && %w(Edge Edg EdgA EdgiOS).include?(agent.last.product)
       end
 
       def browser

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -4,10 +4,6 @@ shared_examples_for "Edge browser" do
   it "should return 'Edge' as its browser" do
     expect(@useragent.browser).to eq("Edge")
   end
-
-  it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
 end
 
 describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" do
@@ -19,6 +15,10 @@ describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, l
 
   it "should return '12.10240' as its version" do
     expect(@useragent.version).to eq("12.10240")
+  end
+
+  it "should return 'Windows' as its platform" do
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 10' as its os" do
@@ -37,6 +37,10 @@ describe "Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Win
     expect(@useragent.version).to eq("13.10586")
   end
 
+  it "should return 'Windows' as its platform" do
+    expect(@useragent.platform).to eq("Windows")
+  end
+
   it "should return 'Windows 10' as its os" do
     expect(@useragent.os).to eq("Windows 10")
   end
@@ -53,7 +57,31 @@ describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, l
     expect(@useragent.version).to eq("74.1.96.24")
   end
 
+  it "should return 'Windows' as its platform" do
+    expect(@useragent.platform).to eq("Windows")
+  end
+
   it "should return 'Windows 10' as its os" do
     expect(@useragent.os).to eq("Windows 10")
+  end
+end
+
+describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36 Edg/88.0.705.56" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36 Edg/88.0.705.56")
+  end
+
+  it_should_behave_like "Edge browser"
+
+  it "should return '88.0.705.56' as its version" do
+    expect(@useragent.version).to eq("88.0.705.56")
+  end
+
+  it "should return 'Macintosh' as its platform" do
+    expect(@useragent.platform).to eq("Macintosh")
+  end
+
+  it "should return 'OS X 10.15.7' as its os" do
+    expect(@useragent.os).to eq("OS X 10.15.7")
   end
 end

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -85,3 +85,43 @@ describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KH
     expect(@useragent.os).to eq("OS X 10.15.7")
   end
 end
+
+describe "Mozilla/5.0 (Linux; Android 10; Pixel 3 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.141 Mobile Safari/537.36 EdgA/45.12.4.5125" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 10; Pixel 3 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.141 Mobile Safari/537.36 EdgA/45.12.4.5125")
+  end
+
+  it_should_behave_like "Edge browser"
+
+  it "should return '45.12.4.5125' as its version" do
+    expect(@useragent.version).to eq("45.12.4.5125")
+  end
+
+  it "should return 'Android' as its platform" do
+    expect(@useragent.platform).to eq("Android")
+  end
+
+  it "should return 'Android 10' as its os" do
+    expect(@useragent.os).to eq("Android 10")
+  end
+end
+
+describe "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1")
+  end
+
+  it_should_behave_like "Edge browser"
+
+  it "should return '41.1.35.1' as its version" do
+    expect(@useragent.version).to eq("41.1.35.1")
+  end
+
+  it "should return 'iPhone' as its platform" do
+    expect(@useragent.platform).to eq("iPhone")
+  end
+
+  it "should return 'iOS 10.3.2' as its os" do
+    expect(@useragent.os).to eq("iOS 10.3.2")
+  end
+end


### PR DESCRIPTION
Edge is now available on Mac, but "useragent" currently reports it as Windows. This PR adds support for OSes other than Windows.