### PR TITLE
Specify whether each browser is a web browser or not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ cache: bundler
 sudo: false
 
 before_install:
-  - gem update --system 3.4.22 # locking to a version compatible with Ruby 3.0
+  - gem update --system
   # Update bundler to the latest
   - gem install bundler
 
 rvm:
-  - 3.0
   - 3.1
+  - 3.2
+  - 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 sudo: false
 
 before_install:
-  - gem update --system
+  - gem update --system 3.4.22 # locking to a version compatible with Ruby 3.0
   # Update bundler to the latest
   - gem install bundler
 

--- a/lib/user_agent/browsers/base.rb
+++ b/lib/user_agent/browsers/base.rb
@@ -76,6 +76,10 @@ class UserAgent
         application && application.product
       end
 
+      def web_browser?
+        false
+      end
+
       def version
         application && application.version
       end

--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -23,6 +23,10 @@ class UserAgent
         webkit.version
       end
 
+      def web_browser?
+        true
+      end
+
       # Prior to Safari 3, the user agent did not include a version number
       def version
         str = if detect_product("CriOs")

--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -51,6 +51,10 @@ class UserAgent
         end
       end
 
+      def web_browser?
+        true
+      end
+
       private
 
       def os_comment

--- a/lib/user_agent/browsers/gecko.rb
+++ b/lib/user_agent/browsers/gecko.rb
@@ -21,6 +21,10 @@ class UserAgent
         GeckoBrowsers.detect { |browser| respond_to?(browser) } || super
       end
 
+      def web_browser?
+        true
+      end
+
       def version
         v = send(browser).version
         v.nil? ? super : v

--- a/lib/user_agent/browsers/internet_explorer.rb
+++ b/lib/user_agent/browsers/internet_explorer.rb
@@ -22,6 +22,10 @@ class UserAgent
         "Internet Explorer"
       end
 
+      def web_browser?
+        true
+      end
+
       def version
         str = application.comment.join('; ')[/(MSIE\s|rv:)([\d\.]+)/, 2]
         Version.new(str)

--- a/lib/user_agent/browsers/opera.rb
+++ b/lib/user_agent/browsers/opera.rb
@@ -15,6 +15,10 @@ class UserAgent
         'Opera'
       end
 
+      def web_browser?
+        true
+      end
+
       def version
         if mini?
           Version.new(application.comment.detect{|c| c =~ /Opera Mini/}[/Opera Mini\/([\d\.]+)/, 1]) rescue Version.new

--- a/lib/user_agent/browsers/samsung.rb
+++ b/lib/user_agent/browsers/samsung.rb
@@ -22,6 +22,10 @@ class UserAgent
       def browser
         'Samsung Internet Browser'
       end
+
+      def web_browser?
+        true
+      end
     end
   end
 end

--- a/lib/user_agent/browsers/vivaldi.rb
+++ b/lib/user_agent/browsers/vivaldi.rb
@@ -39,6 +39,10 @@ class UserAgent
         end
       end
 
+      def web_browser?
+        true
+      end
+
       def webkit
         detect_product("AppleWebKit")
       end

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -91,8 +91,11 @@ class UserAgent
       end
 
       def web_browser?
-        true
+        return true if instance_of?(Webkit) && (detect_product('Version') || browser == 'Safari')
+
+        super
       end
+
 
       def webkit
         if product_match = detect { |useragent| useragent.product =~ WEBKIT_PRODUCT_REGEXP }

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -91,11 +91,10 @@ class UserAgent
       end
 
       def web_browser?
-        return true if instance_of?(Webkit) && (detect_product('Version') || browser == 'Safari')
+        return true if instance_of?(Webkit)
 
         super
       end
-
 
       def webkit
         if product_match = detect { |useragent| useragent.product =~ WEBKIT_PRODUCT_REGEXP }

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -90,6 +90,10 @@ class UserAgent
         end
       end
 
+      def web_browser?
+        true
+      end
+
       def webkit
         if product_match = detect { |useragent| useragent.product =~ WEBKIT_PRODUCT_REGEXP }
           product_match

--- a/lib/user_agent/browsers/wechat_browser.rb
+++ b/lib/user_agent/browsers/wechat_browser.rb
@@ -11,6 +11,10 @@ class UserAgent
         'Wechat Browser'
       end
 
+      def web_browser?
+        true
+      end
+
       def version
         micro_messenger = detect_product("MicroMessenger")
         Version.new(micro_messenger.version)

--- a/spec/browsers/acast_user_agent_spec.rb
+++ b/spec/browsers/acast_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'Acast' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Acast/1.63.0 (Phone; iOS 11.2.6; iPad6,11)" do

--- a/spec/browsers/air_traffic_framework_user_agent_spec.rb
+++ b/spec/browsers/air_traffic_framework_user_agent_spec.rb
@@ -8,7 +8,7 @@ describe UserAgent::Browsers::AirTrafficFramework do
   shared_examples 'an ATC browser' do |version = nil|
     it { expect(user_agent.browser).to eql 'atc' }
     it { expect(user_agent).not_to be_bot }
-    it { expect(useragent).not_to be_web_browser }
+    it { expect(user_agent).not_to be_web_browser }
 
     if version
       it { expect(user_agent.version.to_s).to eql version }

--- a/spec/browsers/air_traffic_framework_user_agent_spec.rb
+++ b/spec/browsers/air_traffic_framework_user_agent_spec.rb
@@ -8,6 +8,7 @@ describe UserAgent::Browsers::AirTrafficFramework do
   shared_examples 'an ATC browser' do |version = nil|
     it { expect(user_agent.browser).to eql 'atc' }
     it { expect(user_agent).not_to be_bot }
+    it { expect(useragent).not_to be_web_browser }
 
     if version
       it { expect(user_agent.version.to_s).to eql version }

--- a/spec/browsers/airr_user_agent_spec.rb
+++ b/spec/browsers/airr_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'Airr' do |version, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Airr/3916 CFNetwork/1202 Darwin/20.1.0" do

--- a/spec/browsers/alexa_user_agent_spec.rb
+++ b/spec/browsers/alexa_user_agent_spec.rb
@@ -30,6 +30,8 @@ shared_examples 'Alexa' do |version, os, type|
     it { expect(useragent).not_to be_speaker }
     it { expect(useragent).not_to be_bot }
   end
+
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: AlexaMediaPlayer/1.0.1560.0 (Linux;Android 10) ExoPlayerLib/1.5.9" do

--- a/spec/browsers/amazon_echo_user_agent_spec.rb
+++ b/spec/browsers/amazon_echo_user_agent_spec.rb
@@ -15,6 +15,7 @@ shared_examples 'Amazon Echo' do |version|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe 'UserAgent: Echo/1.0(APNG)' do

--- a/spec/browsers/amazon_music_user_agent_spec.rb
+++ b/spec/browsers/amazon_music_user_agent_spec.rb
@@ -30,6 +30,8 @@ shared_examples 'Amazon Music' do |version, platform, os, type|
     it { expect(useragent).not_to be_speaker }
     it { expect(useragent).not_to be_bot }
   end
+
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: AmazonMusic/17.7.2 Mozilla/5.0 (Linux; Android 8.1.0; 5059X Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36" do

--- a/spec/browsers/android_download_manager_user_agent_spec.rb
+++ b/spec/browsers/android_download_manager_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'AndroidDownloadManager' do |version, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: AndroidDownloadManager/10 (Linux; U; Android 10; HMA-AL00 Build/HUAWEIHMA-AL00)" do

--- a/spec/browsers/android_user_agent_spec.rb
+++ b/spec/browsers/android_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'Android' do |browser, version, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: ExoPlayerWrapper/5.4.9 (Linux;Android 10) ExoPlayerLib/2.11.5" do

--- a/spec/browsers/apple_home_pod_user_agent_spec.rb
+++ b/spec/browsers/apple_home_pod_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'HomePod' do |version, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: AppleCoreMedia/1.0.0.16A5288c (HomePod; U; CPU OS 12_0 like Mac OS X; en_us)" do

--- a/spec/browsers/apple_podcasts_user_agent_spec.rb
+++ b/spec/browsers/apple_podcasts_user_agent_spec.rb
@@ -30,6 +30,8 @@ shared_examples 'Apple Podcasts with details' do |version, platform, os|
     it { expect(useragent).not_to be_speaker }
     it { expect(useragent).not_to be_bot }
   end
+
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "%D8%A7%D9%84%D8%A8%D9%88%D8%AF%D9%83%D8%A7%D8%B3%D8%AA/1430.27 CFNetwork/1150 Darwin/20.0.0" do

--- a/spec/browsers/audible_user_agent_spec.rb
+++ b/spec/browsers/audible_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'Audible' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: com.audible.playersdk.player/3.6.0 (Linux;Android 10) ExoPlayerLib/2.12.1" do

--- a/spec/browsers/audio_clip_user_agent_spec.rb
+++ b/spec/browsers/audio_clip_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'AudioClip' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: AudioClip/125 CFNetwork/1240.0.4 Darwin/20.5.0" do

--- a/spec/browsers/beyond_pod_user_agent_spec.rb
+++ b/spec/browsers/beyond_pod_user_agent_spec.rb
@@ -15,6 +15,7 @@ shared_examples_for 'BeyondPod' do
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Linux; U; en-us; BeyondPod 4)" do

--- a/spec/browsers/black_berry_user_agent_spec.rb
+++ b/spec/browsers/black_berry_user_agent_spec.rb
@@ -19,6 +19,7 @@ shared_examples 'BlackBerry' do |version|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: BlackBerry8520/5.0.0.681 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/600" do

--- a/spec/browsers/breaker_user_agent_spec.rb
+++ b/spec/browsers/breaker_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Breaker' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Breaker/Android/1.0.0.RC-GP-Free(72) (72)" do

--- a/spec/browsers/castbox_user_agent_spec.rb
+++ b/spec/browsers/castbox_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Castbox' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: CastBox/4.20 (fm.castbox.audiobook.radio.podcast; build:15; iOS 14.4.0)" do

--- a/spec/browsers/castro_user_agent_spec.rb
+++ b/spec/browsers/castro_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Castro' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Castro 2021.4/1322" do

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -30,6 +30,7 @@ shared_examples 'Chrome browser' do |version, platform, os, type|
   end
 
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).to be_web_browser }
 end
 
 # http://www.useragentstring.com/Chrome30.0.1599.17_id_19721.php

--- a/spec/browsers/deezer_crawler_user_agent_spec.rb
+++ b/spec/browsers/deezer_crawler_user_agent_spec.rb
@@ -14,6 +14,7 @@ shared_examples 'DeezerCrawler' do
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Deezer Podcasters/1.0" do

--- a/spec/browsers/deezer_user_agent_spec.rb
+++ b/spec/browsers/deezer_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples 'Deezer' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Deezer/6.2.28.73 (Android; 11; Mobile; fr) samsung SM-G973F" do

--- a/spec/browsers/downcast_crawler_user_agent_spec.rb
+++ b/spec/browsers/downcast_crawler_user_agent_spec.rb
@@ -14,6 +14,7 @@ shared_examples 'DowncastCrawler' do
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: downcast feed consumer/0.0.177; (mode=dev; id=jQPkOYXFJT; downcast.fm)" do

--- a/spec/browsers/downcast_user_agent_spec.rb
+++ b/spec/browsers/downcast_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples_for 'Downcast' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Downcast/2.10.3 (iPhone; iOS 14.6; Scale/3.00)" do

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples 'Edge browser' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" do

--- a/spec/browsers/facebook_user_agent_spec.rb
+++ b/spec/browsers/facebook_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples 'Facebook' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Linux; Android 5.1; XT1039 Build/LPBS23.13-17.6-1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.116 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/137.0.0.24.91;]" do

--- a/spec/browsers/gecko_user_agent_spec.rb
+++ b/spec/browsers/gecko_user_agent_spec.rb
@@ -17,6 +17,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 shared_examples 'a mobile' do
@@ -24,6 +25,7 @@ shared_examples 'a mobile' do
   it { expect(@useragent).not_to be_desktop }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8' do

--- a/spec/browsers/gecko_user_agent_spec.rb
+++ b/spec/browsers/gecko_user_agent_spec.rb
@@ -17,7 +17,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 shared_examples 'a mobile' do

--- a/spec/browsers/gecko_user_agent_spec.rb
+++ b/spec/browsers/gecko_user_agent_spec.rb
@@ -25,7 +25,7 @@ shared_examples 'a mobile' do
   it { expect(@useragent).not_to be_desktop }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8' do

--- a/spec/browsers/google_home_user_agent_spec.rb
+++ b/spec/browsers/google_home_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for "Google Home" do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Linux; Android 6.0.1; Build/M-MMB29M-rzs-us-sf-bld2-19HP-08.02.AM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.41 Safari/537.36 CrKey/1.29.104695" do

--- a/spec/browsers/google_podcasts_user_agent_spec.rb
+++ b/spec/browsers/google_podcasts_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Google Podcasts' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) GSA/42.0.183854831 Mobile/13G36 Safari/601.1" do

--- a/spec/browsers/googlebot_user_agent_spec.rb
+++ b/spec/browsers/googlebot_user_agent_spec.rb
@@ -13,6 +13,7 @@ shared_examples_for 'Googlebot' do
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Googlebot" do

--- a/spec/browsers/himalaya_user_agent_spec.rb
+++ b/spec/browsers/himalaya_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Himalaya' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Himalaya/2.4.82 Android/29 (EVR-L29)" do

--- a/spec/browsers/icatcher_user_agent_spec.rb
+++ b/spec/browsers/icatcher_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'iCatcher!' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: iCatcher!/6.7.5 (iPhone; iOS 14.5.1; Scale/2.0)" do

--- a/spec/browsers/iheart_radio_user_agent_spec.rb
+++ b/spec/browsers/iheart_radio_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'iHeartRadio' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: iHeartRadio/1 CFNetwork/1098.6 Darwin/19.0.0" do

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -21,7 +21,7 @@ shared_examples_for "Internet Explorer browser" do |type = :desktop|
 
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" do

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -21,6 +21,7 @@ shared_examples_for "Internet Explorer browser" do |type = :desktop|
 
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" do

--- a/spec/browsers/iron_user_agent_spec.rb
+++ b/spec/browsers/iron_user_agent_spec.rb
@@ -17,7 +17,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 # http://www.useragentstring.com/Iron22.0.2150.0_id_19368.php

--- a/spec/browsers/iron_user_agent_spec.rb
+++ b/spec/browsers/iron_user_agent_spec.rb
@@ -17,6 +17,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 # http://www.useragentstring.com/Iron22.0.2150.0_id_19368.php

--- a/spec/browsers/itunes_user_agent_spec.rb
+++ b/spec/browsers/itunes_user_agent_spec.rb
@@ -15,6 +15,7 @@ shared_examples "iTunes" do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 shared_examples "iTunes runs on" do |platform, os|

--- a/spec/browsers/itunes_user_agent_spec.rb
+++ b/spec/browsers/itunes_user_agent_spec.rb
@@ -15,7 +15,7 @@ shared_examples "iTunes" do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).not_to be_web_browser }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 shared_examples "iTunes runs on" do |platform, os|

--- a/spec/browsers/luminary_user_agent_spec.rb
+++ b/spec/browsers/luminary_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Luminary' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Luminary/33.0 (Android 9; SM-G950F; samsung dreamlte; en)" do

--- a/spec/browsers/npr_one_user_agent_spec.rb
+++ b/spec/browsers/npr_one_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'NPR One' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: NPROneAndroid" do

--- a/spec/browsers/ok_http_user_agent_spec.rb
+++ b/spec/browsers/ok_http_user_agent_spec.rb
@@ -28,6 +28,7 @@ shared_examples 'OkHttp' do |version, platform, os, type|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: okhttp/3.8.1" do

--- a/spec/browsers/opera_user_agent_spec.rb
+++ b/spec/browsers/opera_user_agent_spec.rb
@@ -24,6 +24,7 @@ shared_examples_for "Opera browser" do |type|
 
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 # http://www.useragentstring.com/Opera12.14_id_19612.php

--- a/spec/browsers/opera_user_agent_spec.rb
+++ b/spec/browsers/opera_user_agent_spec.rb
@@ -24,7 +24,7 @@ shared_examples_for "Opera browser" do |type|
 
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 # http://www.useragentstring.com/Opera12.14_id_19612.php

--- a/spec/browsers/other_user_agent_spec.rb
+++ b/spec/browsers/other_user_agent_spec.rb
@@ -27,7 +27,7 @@ describe "UserAgent: nil" do
   it { expect(@useragent).not_to be_bot }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
-  it { expect(useragent).not_to be_web_browser }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: ''" do

--- a/spec/browsers/other_user_agent_spec.rb
+++ b/spec/browsers/other_user_agent_spec.rb
@@ -27,7 +27,7 @@ describe "UserAgent: nil" do
   it { expect(@useragent).not_to be_bot }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
-  it { expect(@useragent).not_to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: ''" do
@@ -55,6 +55,7 @@ describe "UserAgent: ''" do
   it { expect(@useragent).not_to be_bot }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible)'" do
@@ -82,6 +83,7 @@ describe "UserAgent: 'Mozilla/4.0 (compatible)'" do
   it { expect(@useragent).not_to be_bot }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: 'Mozilla/5.0'" do
@@ -109,6 +111,7 @@ describe "UserAgent: 'Mozilla/5.0'" do
   it { expect(@useragent).not_to be_bot }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: 'amaya/9.51 libwww/5.4.0'" do
@@ -127,6 +130,8 @@ describe "UserAgent: 'amaya/9.51 libwww/5.4.0'" do
   it "should return '5.4.0' as its libwww version" do
     expect(@useragent.libwww.version).to eq("5.4.0")
   end
+
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: 'Rails Testing'" do
@@ -144,6 +149,7 @@ describe "UserAgent: 'Rails Testing'" do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: 'Python-urllib/2.7'" do
@@ -164,6 +170,7 @@ describe "UserAgent: 'Python-urllib/2.7'" do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: 'check_http/v1.4.15 (nagios-plugins 1.4.15)'" do
@@ -184,6 +191,7 @@ describe "UserAgent: 'check_http/v1.4.15 (nagios-plugins 1.4.15)'" do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: '/WebTest.pm'" do
@@ -194,4 +202,6 @@ describe "UserAgent: '/WebTest.pm'" do
   it "should return nil as its browser" do
     expect(@useragent.browser).to eq(nil)
   end
+
+  it { expect(@useragent).not_to be_web_browser }
 end

--- a/spec/browsers/other_user_agent_spec.rb
+++ b/spec/browsers/other_user_agent_spec.rb
@@ -27,6 +27,7 @@ describe "UserAgent: nil" do
   it { expect(@useragent).not_to be_bot }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_desktop }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: ''" do

--- a/spec/browsers/overcast_user_agent_spec.rb
+++ b/spec/browsers/overcast_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples 'Overcast' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Overcast/3.0 (+http://overcast.fm/; iOS podcast app) BMID/E6793162B9" do

--- a/spec/browsers/pandora_rss_crawler_user_agent_spec.rb
+++ b/spec/browsers/pandora_rss_crawler_user_agent_spec.rb
@@ -17,6 +17,7 @@ shared_examples_for 'PandoraRSSCrawler' do |version|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "PandoraRSSCrawler/1.0 (podcastpartnerships@pandora.com)" do

--- a/spec/browsers/pandora_user_agent_spec.rb
+++ b/spec/browsers/pandora_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples_for 'Pandora' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "Mozilla/5.0 (iPad; CPU OS 10_3_4 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G61 Pandora/1812.1" do

--- a/spec/browsers/playstation_user_agent_spec.rb
+++ b/spec/browsers/playstation_user_agent_spec.rb
@@ -15,7 +15,7 @@ shared_examples 'PlayStation 3' do
     expect(@useragent.mobile?).to be false
   end
 
-  it { expect(useragent).not_to be_web_browser }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)" do

--- a/spec/browsers/playstation_user_agent_spec.rb
+++ b/spec/browsers/playstation_user_agent_spec.rb
@@ -14,6 +14,8 @@ shared_examples 'PlayStation 3' do
   it 'returns false for mobile?' do
     expect(@useragent.mobile?).to be false
   end
+
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)" do

--- a/spec/browsers/pocket_casts_user_agent_spec.rb
+++ b/spec/browsers/pocket_casts_user_agent_spec.rb
@@ -38,6 +38,7 @@ shared_examples 'Pocket Casts' do |version, platform, os, type|
   end
 
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Pocket Casts BMID/E678F58F21" do

--- a/spec/browsers/pod_2_watch_spec.rb
+++ b/spec/browsers/pod_2_watch_spec.rb
@@ -11,6 +11,7 @@ describe UserAgent::Browsers::Pod2Watch do
     it { expect(user_agent).to be_mobile }
     it { expect(user_agent.os).to eql ['watchOS', os_version].compact.join(' ') }
     it { expect(user_agent.platform).to eql 'Apple Watch' }
+    it { expect(useragent).not_to be_web_browser }
 
     if version
       it { expect(user_agent.version.to_s).to eql version }

--- a/spec/browsers/pod_2_watch_spec.rb
+++ b/spec/browsers/pod_2_watch_spec.rb
@@ -11,7 +11,7 @@ describe UserAgent::Browsers::Pod2Watch do
     it { expect(user_agent).to be_mobile }
     it { expect(user_agent.os).to eql ['watchOS', os_version].compact.join(' ') }
     it { expect(user_agent.platform).to eql 'Apple Watch' }
-    it { expect(useragent).not_to be_web_browser }
+    it { expect(user_agent).not_to be_web_browser }
 
     if version
       it { expect(user_agent.version.to_s).to eql version }

--- a/spec/browsers/pod_mn_user_agent_spec.rb
+++ b/spec/browsers/pod_mn_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'PodMN' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: PodMN/Android 1.3.1 (Android 11; SM-G970U Build/RP1A.200720.012)" do

--- a/spec/browsers/podbean_user_agent_spec.rb
+++ b/spec/browsers/podbean_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'Podbean' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Podbean/Android App 8.5.1 (http://podbean.com),a3d7ec202761774354efde899ad29a6a" do

--- a/spec/browsers/podcast_addict_user_agent_spec.rb
+++ b/spec/browsers/podcast_addict_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'Podcast Addict' do |version, os, security = :strong|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)" do

--- a/spec/browsers/podcast_republic_user_agent_spec.rb
+++ b/spec/browsers/podcast_republic_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Podcast Republic' do |version, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: PodcastRepublic/18.0 (Linux; U; Android 11;blueline/RQ2A.210505.002)" do

--- a/spec/browsers/podimo_user_agent_spec.rb
+++ b/spec/browsers/podimo_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Podimo' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Podimo/1.39.4 build 290/Android 30" do

--- a/spec/browsers/podkicker_user_agent_spec.rb
+++ b/spec/browsers/podkicker_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Podkicker' do |version|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Podkicker Pro/3.1.19.RC-GP-Pro(2028)" do

--- a/spec/browsers/podverse_user_agent_spec.rb
+++ b/spec/browsers/podverse_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Podverse' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Podverse/F-Droid Android Mobile App/" do

--- a/spec/browsers/radio_public_crawler_user_agent_spec.rb
+++ b/spec/browsers/radio_public_crawler_user_agent_spec.rb
@@ -14,6 +14,7 @@ shared_examples 'RadioPublicCrawler' do
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: RadioPublic-Web/e0d2cd1" do

--- a/spec/browsers/radio_public_user_agent_spec.rb
+++ b/spec/browsers/radio_public_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'RadioPublic' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: RadioPublic/android-2.2" do

--- a/spec/browsers/samsung_user_agent_spec.rb
+++ b/spec/browsers/samsung_user_agent_spec.rb
@@ -21,6 +21,7 @@ shared_examples 'SamsungBrowser' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G991B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36" do

--- a/spec/browsers/sonos_user_agent_spec.rb
+++ b/spec/browsers/sonos_user_agent_spec.rb
@@ -20,6 +20,7 @@ shared_examples 'Sonos' do |version|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Linux UPnP/1.0 Sonos/44.2-53100-mainline_integ (ZPS120)" do

--- a/spec/browsers/sound_on_user_agent_spec.rb
+++ b/spec/browsers/sound_on_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'SoundOn' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: SoundOn/3.7.1 (Linux;Android)" do

--- a/spec/browsers/spotify_user_agent_spec.rb
+++ b/spec/browsers/spotify_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples 'Spotify' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Spotify/0.1.118.48 Android/29 (Pixel 4 XL)" do

--- a/spec/browsers/spreaker_user_agent_spec.rb
+++ b/spec/browsers/spreaker_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples_for 'Spreaker' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Spreaker for Android 4.17.0 release:2021-05-05 device:phone (samsung SM-G965U; Android 10; en_US)" do

--- a/spec/browsers/stagefright_user_agent_spec.rb
+++ b/spec/browsers/stagefright_user_agent_spec.rb
@@ -6,6 +6,8 @@ shared_examples 'Android platform' do
   it "returns 'Android' as its platform" do
     expect(useragent.platform).to eq('Android')
   end
+
+  it { expect(useragent).not_to be_web_browser }
 end
 
 shared_examples 'Stagefright' do

--- a/spec/browsers/stitcher_bot_user_agent_spec.rb
+++ b/spec/browsers/stitcher_bot_user_agent_spec.rb
@@ -13,6 +13,7 @@ shared_examples_for 'Stitcherbot' do
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_mobile }
   it { expect(useragent).not_to be_speaker }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: stitcherbot (http://www.stitcher.com)" do

--- a/spec/browsers/stitcher_user_agent_spec.rb
+++ b/spec/browsers/stitcher_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples 'Stitcher' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: Stitcher/iOS BMID/E675DDB007" do

--- a/spec/browsers/the_podcast_app_user_agent_spec.rb
+++ b/spec/browsers/the_podcast_app_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'ThePodcastApp' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: ThePodcastApp/5.6.1 (iPhone; iOS 14.6; ) player (build 4958; +https://podcast.app/)" do

--- a/spec/browsers/tune_in_user_agent_spec.rb
+++ b/spec/browsers/tune_in_user_agent_spec.rb
@@ -29,6 +29,7 @@ shared_examples 'TuneIn' do |version, platform, os, type|
 
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 describe "UserAgent: TuneIn Radio/26.8.1 (Linux;Android 8.0.0) ExoPlayerLib/2.12.2" do

--- a/spec/browsers/vivaldi_user_agent_spec.rb
+++ b/spec/browsers/vivaldi_user_agent_spec.rb
@@ -11,6 +11,7 @@ shared_examples_for "Vivaldi browser" do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do

--- a/spec/browsers/vivaldi_user_agent_spec.rb
+++ b/spec/browsers/vivaldi_user_agent_spec.rb
@@ -11,7 +11,7 @@ shared_examples_for "Vivaldi browser" do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -17,7 +17,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 shared_examples 'a mobile' do

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -25,7 +25,7 @@ shared_examples 'a mobile' do
   it { expect(@useragent).not_to be_desktop }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16" do

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -17,6 +17,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 shared_examples 'a mobile' do
@@ -24,6 +25,7 @@ shared_examples 'a mobile' do
   it { expect(@useragent).not_to be_desktop }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).to be_web_browser }
 end
 
 describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16" do

--- a/spec/browsers/wechat_browser_user_agent_spec.rb
+++ b/spec/browsers/wechat_browser_user_agent_spec.rb
@@ -23,7 +23,7 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) Ap
     expect(@useragent.os).to eq("iOS 9.3.1")
   end
 
-  it { expect(useragent).to be_web_browser }
+  it { expect(@useragent).to be_web_browser }
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN'" do

--- a/spec/browsers/wechat_browser_user_agent_spec.rb
+++ b/spec/browsers/wechat_browser_user_agent_spec.rb
@@ -22,6 +22,8 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) Ap
   it "should return 'iOS 9.3.1' as its os" do
     expect(@useragent.os).to eq("iOS 9.3.1")
   end
+
+  it { expect(useragent).to be_web_browser }
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN'" do

--- a/spec/browsers/windows_media_player_user_agent_spec.rb
+++ b/spec/browsers/windows_media_player_user_agent_spec.rb
@@ -7,6 +7,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 shared_examples 'a mobile' do
@@ -14,6 +15,7 @@ shared_examples 'a mobile' do
   it { expect(@useragent).not_to be_desktop }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 shared_examples "Windows Media Player" do

--- a/spec/browsers/windows_media_player_user_agent_spec.rb
+++ b/spec/browsers/windows_media_player_user_agent_spec.rb
@@ -7,7 +7,7 @@ shared_examples 'a desktop' do
   it { expect(@useragent).not_to be_mobile }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).not_to be_web_browser }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 shared_examples 'a mobile' do

--- a/spec/browsers/windows_media_player_user_agent_spec.rb
+++ b/spec/browsers/windows_media_player_user_agent_spec.rb
@@ -15,7 +15,7 @@ shared_examples 'a mobile' do
   it { expect(@useragent).not_to be_desktop }
   it { expect(@useragent).not_to be_speaker }
   it { expect(@useragent).not_to be_bot }
-  it { expect(useragent).not_to be_web_browser }
+  it { expect(@useragent).not_to be_web_browser }
 end
 
 shared_examples "Windows Media Player" do

--- a/spec/browsers/wondery_user_agent_spec.rb
+++ b/spec/browsers/wondery_user_agent_spec.rb
@@ -23,6 +23,7 @@ shared_examples 'Wondery' do |version, platform, os|
   it { expect(useragent).not_to be_desktop }
   it { expect(useragent).not_to be_speaker }
   it { expect(useragent).not_to be_bot }
+  it { expect(useragent).not_to be_web_browser }
 end
 
 shared_examples 'Wondery Crawler' do |version|


### PR DESCRIPTION
Specifies whether the "browser" is a web browser or not. 

I confirmed that the Spotify web player/Amazon music web player/Apple Podcasts web player all have the actual web browser UA. So nothing fancy here besides checking if the UA is coming from a web browser.